### PR TITLE
Add "star" as name for *.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 | `!!` | double bang |
 | `*` | splat |
 | `*` | twinkle |
+| `*` | star |
 | `{}` | braces |
 | `{}` | curly |
 | `{}` | squiggly brackets |


### PR DESCRIPTION
Hey great idea! Did you intentionally leave out "star" as a name for `*`? That's what I've always called it and I think is pretty common.