### PR TITLE
Add `->` thin arrow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 | `->` | lambda literal |
 | `->` | stabby lambda |
 | `->` | dash rocket |
+| `->` | thin arrow |
 | `||=` | pipe bomb |
 | `||=` | assign unless truthy |
 | `||=` | top hat operator |


### PR DESCRIPTION
My co-workers and I have been calling these guys "thin arrows" for over a year now.
As opposed to `=>` fat arrow.